### PR TITLE
add dark theme stylesheet and fix Qt6 WindowStaysOnTopHint flag #19

### DIFF
--- a/japan_elevation/metadata.txt
+++ b/japan_elevation/metadata.txt
@@ -4,7 +4,7 @@ description=Display elevation value of specified position on QGIS
 about=Display elevation value of specified position on QGIS using Elevation API by Geospatial Information Authority of Japan (GSI).
 qgisMinimumVersion=3.34
 qgisMaximumVersion=4.99
-version=4.0.0
+version=4.1.0
 supportsQt6=True
 
 # Plugin main icon

--- a/japan_elevation/ui/dialog/dialog.py
+++ b/japan_elevation/ui/dialog/dialog.py
@@ -4,6 +4,8 @@ from qgis.PyQt import uic
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtWidgets import QDialog
 
+from ..style_loader import load_style
+
 FORM_CLASS, _ = uic.loadUiType(os.path.join(os.path.dirname(__file__), "dialog.ui"))
 
 
@@ -19,8 +21,12 @@ class ElevationDialog(QDialog, FORM_CLASS):
         Initializes the elevation dialog by loading the UI components.
         """
         super().__init__(parent)
-        self.setWindowFlags(Qt.WindowStaysOnTopHint)  # type: ignore
+        try:
+            self.setWindowFlags(Qt.WindowType.WindowStaysOnTopHint)
+        except AttributeError:
+            self.setWindowFlags(Qt.WindowStaysOnTopHint)  # type: ignore
         self.setupUi(self)
+        load_style(self)
 
     def set_elevation(self, value: str) -> None:
         """

--- a/japan_elevation/ui/style.qss
+++ b/japan_elevation/ui/style.qss
@@ -1,0 +1,39 @@
+/* ============================================
+   Japan Elevation
+   ============================================ */
+
+/* --- Dialog Base --- */
+QDialog {
+    background-color: #0E0B1A;
+    color: #F0ECF8;
+}
+
+/* --- Field Name Labels (left column) --- */
+QLabel#label_elevation,
+QLabel#label_data {
+    color: #8878B0;
+    font-size: 12px;
+    font-weight: bold;
+    padding: 4px 0px;
+}
+
+/* --- Elevation Value (primary display) --- */
+QLabel#label_elevation_value {
+    background-color: #1A1528;
+    color: #06D6A0;
+    font-size: 20px;
+    font-weight: bold;
+    padding: 8px 12px;
+    border: 1px solid #3D3060;
+    border-radius: 12px;
+}
+
+/* --- Data Source Value --- */
+QLabel#label_data_value {
+    background-color: #1A1528;
+    color: #8878B0;
+    font-size: 13px;
+    padding: 6px 12px;
+    border: 1px solid #3D3060;
+    border-radius: 12px;
+}

--- a/japan_elevation/ui/style_loader.py
+++ b/japan_elevation/ui/style_loader.py
@@ -1,0 +1,24 @@
+import os
+
+from qgis.core import Qgis, QgsMessageLog
+from qgis.PyQt.QtWidgets import QWidget
+
+STYLE_PATH = os.path.join(os.path.dirname(__file__), "style.qss")
+
+
+def load_style(widget: QWidget) -> None:
+    """
+    Loads a QSS stylesheet and applies it to the specified widget.
+
+    Args:
+        widget: The target widget to apply the stylesheet to.
+    """
+    try:
+        with open(STYLE_PATH, encoding="utf-8") as f:
+            widget.setStyleSheet(f.read())
+    except (OSError, UnicodeDecodeError) as e:
+        QgsMessageLog.logMessage(
+            f"Failed to load style: {e!r}",
+            "Japan Elevation",
+            Qgis.Warning,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qgis-japanelevation-plugin"
-version = "4.0.0"
+version = "4.1.0"
 description = "Display elevation value of specified position on QGIS using GSI Japan Elevation API"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
- Add dark theme QSS stylesheet and style_loader module
- Apply stylesheet to MainDialog on initialization
- Update WindowStaysOnTopHint to Qt6 enum with Qt5 fallback